### PR TITLE
fix: SampleApp Docker build failed due to invalid path instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Access information related to pods such as Deployment and ReplicaSet using the K
 
 # Usage
 
+build docker image.
+
+```shell
+docker build -t pripodsampleapp:debug -f samples/Pripod.SampleApp/Dockerfile .
+```
+
 ## Code sample and outputs
 ```csharp
 using Pripod;

--- a/samples/Pripod.SampleApp/Dockerfile
+++ b/samples/Pripod.SampleApp/Dockerfile
@@ -4,10 +4,10 @@ WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2-stretch AS build
 WORKDIR /src
-COPY ["Pripod.SampleApp/Pripod.SampleApp.csproj", "ConsoleApp1/"]
-RUN dotnet restore "Pripod.SampleApp/Pripod.SampleApp.csproj"
+COPY ["samples/Pripod.SampleApp/Pripod.SampleApp.csproj", "samples/Pripod.SampleApp/"]
+RUN dotnet restore "samples/Pripod.SampleApp/Pripod.SampleApp.csproj"
 COPY . .
-WORKDIR "/samples/Pripod.SampleApp"
+WORKDIR "/src/samples/Pripod.SampleApp"
 RUN dotnet build "Pripod.SampleApp.csproj" -c Release -o /app
 
 FROM build AS publish


### PR DESCRIPTION
Dockerfile's path is not follow to actual project path.